### PR TITLE
Timer intervals revised

### DIFF
--- a/src/getRandomChar.js
+++ b/src/getRandomChar.js
@@ -54,4 +54,12 @@ function getRandomChar(chars) {
   }
 }
 
-export default getRandomChar
+function toScifiText(chars, text, keepChars) {
+  let retChars = ''
+  for (let i = 0; i < text.length; i++) {
+    retChars += keepChars.includes(text[i]) ? text[i] : getRandomChar(chars)
+  }
+  return retChars
+}
+
+export default toScifiText

--- a/src/index.js
+++ b/src/index.js
@@ -1,32 +1,35 @@
-import getRandomChar from './getRandomChar'
+import toScifiText from './getRandomChar'
 
 const ATTR = 'data-scifing'
 
-function scifi(el, { content, chars = '[en]', speed = 20, delay = 100 } = {}) {
+function scifi(el, { content, chars = '[en]', scifiSpeed = 20, exposeDelay = 100, keepChars = [' '] } = {}) {
   if (el.getAttribute(ATTR)) return
 
   content = content || el.textContent
   el.setAttribute(ATTR, true)
-  let finishedString = ''
 
-  const randomTimer = setInterval(() => {
-    let randomString = ''
-    for (let i = 0; i < content.length - finishedString.length; i++) {
-      // Ignore space
-      randomString += content[i + finishedString.length] === ' ' ? ' ' : getRandomChar(chars)
-    }
-    el.textContent = finishedString + randomString
-  }, speed)
-
-  const finishedTimer = setInterval(() => {
-    if (finishedString.length < content.length) {
-      finishedString += content[finishedString.length]
+  let exposePosition = 0
+  const exposeTimer = setInterval(() => {
+    if (exposePosition < content.length) {
+      exposePosition++
     } else {
-      clearInterval(finishedTimer)
-      clearInterval(randomTimer)
-      el.removeAttribute(ATTR)
+      exposePosition = content.length
+      clearInterval(exposeTimer)
     }
-  }, delay)
+  }, exposeDelay)
+
+  const scifiTimer = setInterval(() => {
+    el.textContent = content.substr(0, exposePosition)
+
+    if(exposePosition < content.length) {
+      el.textContent += toScifiText(chars, content.substr(exposePosition - content.length), keepChars)
+    }
+
+    if (el.textContent === content) {
+      el.removeAttribute(ATTR)
+      clearInterval(scifiTimer)
+    }
+  }, scifiSpeed)
 }
 
 export default scifi


### PR DESCRIPTION
- Added function to get multiple random characters at once
- Invervals responsible for clearing themselves
- Expose interval continues until reaching end of content string
- Scifi interval continues until display text matches original content
- Config values renamed to 'scifiSpeed' and 'exposeDelay' for clarity
- Support added for using a scifiSpeed higher than exposeDelay value